### PR TITLE
Fix Map on Web Servers

### DIFF
--- a/fm/generateIndex.lua
+++ b/fm/generateIndex.lua
@@ -15,7 +15,9 @@ function fm.generateIndex(data)
 </style>
 <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
 <title>Factorio Maps</title>
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<!-- For local use, don't change anything. For server (making it available on a website) use, get a Google Maps API key (get one here: https://developers.google.com/maps/documentation/javascript/get-api-key), paste your key in the line below this one where it says "INSERTAPIKEY", uncomment the line below and two lines down delete the second <!-- and the first --> 
+ <!-- <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=INSERTAPIKEY"></script> -->
+ <!-- --> <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script> <!-- -->
 <script>
 function CustomMapType() {}
 


### PR DESCRIPTION
Google Maps updated their API. The map won't load properly when uploaded to a web server (making it available on a website). This code change fixes this while still maintaining local support. You do have to get a Google Maps API key for uploading it to a web server but they are free with a Google account for the first 25,000 map loads per 24 hours, which isn't bad.