### PR TITLE
Removed window.onHashChange causing a event loop

### DIFF
--- a/fm/generateIndex.lua
+++ b/fm/generateIndex.lua
@@ -123,10 +123,6 @@ function hash_changed() {
     }
 }
 
-if ("onhashchange" in window) {
-    window.onhashchange = hash_changed
-}
-
 function load() {
     var mapOptions = {
         zoom: ]].. (data.index.minZoomLevel) ..[[,


### PR DESCRIPTION
Tested in Chrome 36 - Removing this code allows the map to pan again - while still enabling a URL hash for linking to a specific location/zoom level on page load.